### PR TITLE
#06 - Cache Policy Changed

### DIFF
--- a/SamplePokemonApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SamplePokemonApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/SamplePokemonApp.xcodeproj/project.xcworkspace/xcuserdata/developer.heshantha.don.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/SamplePokemonApp.xcodeproj/project.xcworkspace/xcuserdata/developer.heshantha.don.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>Default</string>
+	<key>ShowSharedSchemesAutomaticallyEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/SamplePokemonApp/Managers/NetworkManager/NetworkManager.swift
+++ b/SamplePokemonApp/Managers/NetworkManager/NetworkManager.swift
@@ -20,7 +20,7 @@ actor NetworkManager: NetworkManagerProtocal {
     func fetchData<T>(_ endpoint: ApiEndPoint) async throws -> T? where T : Decodable {
         guard let url = URL(string: endpoint.url) else { throw ApiError.badUrl }
         
-        var request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData)
+        var request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
         request.httpMethod = endpoint.method.rawValue
         let (data, response) = try await URLSession.shared.data(for: request)
         

--- a/SamplePokemonAppTests/HomeViewModelTests.swift
+++ b/SamplePokemonAppTests/HomeViewModelTests.swift
@@ -42,7 +42,7 @@ final class HomeViewModelTests: XCTestCase {
             .store(in: &cancellable)
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             await fulfillment(of: [expectation], timeout: 5)
         } catch {
             XCTFail("Expected success but got error: \(error)")
@@ -61,7 +61,7 @@ final class HomeViewModelTests: XCTestCase {
             .store(in: &cancellable)
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             try await Task.sleep(for: .seconds(3))
         } catch {
             XCTFail("Expected success but got error: \(error)")
@@ -73,7 +73,7 @@ final class HomeViewModelTests: XCTestCase {
         let pokemonName = MocPokemon.POKEMON_NAME.PIKACHU
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             try await Task.sleep(for: .seconds(3))
             let pokemons = sut.searchPokemon(by: pokemonName)
             
@@ -93,7 +93,7 @@ final class HomeViewModelTests: XCTestCase {
         let pokemonName = "NOT A POKEMON NAME"
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             try await Task.sleep(for: .seconds(3))
             let pokemons = sut.searchPokemon(by: pokemonName)
             
@@ -109,7 +109,7 @@ final class HomeViewModelTests: XCTestCase {
         let pokemonName = ""
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             try await Task.sleep(for: .seconds(3))
             let pokemons = sut.searchPokemon(by: pokemonName)
             
@@ -125,7 +125,7 @@ final class HomeViewModelTests: XCTestCase {
         let pokemonName = ""
         
         do {
-            try sut.fetchData()
+            try await sut.fetchData()
             try await Task.sleep(for: .seconds(3))
             let pokemons = sut.searchPokemon(by: pokemonName)
             
@@ -153,7 +153,7 @@ final class HomeViewModelTests: XCTestCase {
             .store(in: &cancellable)
         
         do {
-            await sut.searchPokemonFromService(by: pokemonName)
+            try await sut.searchPokemonFromService(by: pokemonName)
             await fulfillment(of: [expectation], timeout: 5)
             
         } catch {
@@ -177,7 +177,7 @@ final class HomeViewModelTests: XCTestCase {
             .store(in: &cancellable)
         
         do {
-            await sut.searchPokemonFromService(by: pokemonName)
+            try await sut.searchPokemonFromService(by: pokemonName)
             await fulfillment(of: [expectation], timeout: 5)
             
         } catch {


### PR DESCRIPTION
## **PR number: 06** | **Ticket number: 00**
## What's new
- Changed URLSession cache policy to 'returnCacheDataElseLoad'. This policy instructs URLCache to return a cached response if available; otherwise, it fetches the data from the network. 
- Fixed bugs in Home View Model and its test cases.
## Did it increase the warnings count? 
- NO